### PR TITLE
9 feat/전역 예외 처리 추가

### DIFF
--- a/src/main/java/com/sayye/exception/ApiException.java
+++ b/src/main/java/com/sayye/exception/ApiException.java
@@ -1,0 +1,11 @@
+package com.sayye.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ApiException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/sayye/exception/ErrorCode.java
+++ b/src/main/java/com/sayye/exception/ErrorCode.java
@@ -1,0 +1,29 @@
+package com.sayye.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러가 발생했습니다.");
+
+    // 관리자
+
+
+
+    // 클래스
+
+
+
+    // 회의실
+
+
+
+    // 예약
+
+    private final HttpStatus status;
+    private final String message;
+
+}

--- a/src/main/java/com/sayye/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sayye/exception/GlobalExceptionHandler.java
@@ -1,0 +1,45 @@
+package com.sayye.exception;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<String> handleCustomException(ApiException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        log.warn("handleCustomException: {}", errorCode, e);
+
+        return ResponseEntity
+            .status(errorCode.getStatus())
+            .body(errorCode.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidationException(
+        MethodArgumentNotValidException e) {
+
+        Map<String, String> errors = e.getBindingResult() // 검증 결과
+            .getFieldErrors() // 필드 에러만 가져옴
+            .stream()
+            .collect(Collectors.toMap(
+                FieldError::getField, // 필드 이름을 key로
+                FieldError::getDefaultMessage // 기본 메시지를 value로 (validation에 작성한 메시지)
+            ));
+
+        log.warn("Validation failed: {}", errors, e);
+
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(errors);
+    }
+}


### PR DESCRIPTION
### 작업 내용
* 전역 예외 처리 관련 클래스를 추가했습니다.
   * 서비스단에서 예외를 발생시켜야 할 때 `throw new ApiException(ErrorCode.XXX)` 형태로 사용해주시면 됩니다.
   * dto validation 예외 처리 메서드를 만들어두긴 했는데 응답 형식을 확인해보지는 못해서 제대로 응답되지 않으면 추후 수정이 필요할 것 같습니다.
