### PR TITLE
14 feat 예약 삭제 기능 구현

### DIFF
--- a/src/main/java/com/sayye/exception/ErrorCode.java
+++ b/src/main/java/com/sayye/exception/ErrorCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러가 발생했습니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러가 발생했습니다."),
 
     // 관리자
 
@@ -22,6 +22,9 @@ public enum ErrorCode {
 
 
     // 예약
+    RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다."),
+    RESERVATION_CANCEL_UNAUTHORIZED(HttpStatus.FORBIDDEN, "예약자 정보가 일치하지 않습니다."),
+    RESERVATION_CANCEL_TIME_EXCEEDED(HttpStatus.FORBIDDEN, "예약 시작 1시간 전에는 취소할 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/sayye/reservation/controller/ReservationController.java
+++ b/src/main/java/com/sayye/reservation/controller/ReservationController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping("/api/reservations")
+@RequestMapping("/reservations")
 @RequiredArgsConstructor
 @RestController
 public class ReservationController {

--- a/src/main/java/com/sayye/reservation/controller/ReservationController.java
+++ b/src/main/java/com/sayye/reservation/controller/ReservationController.java
@@ -1,0 +1,28 @@
+package com.sayye.reservation.controller;
+
+import com.sayye.reservation.dto.CancelReservationReqDto;
+import com.sayye.reservation.service.ReservationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/reservations")
+@RequiredArgsConstructor
+@RestController
+public class ReservationController {
+
+    private final ReservationService reservationService;
+
+    @DeleteMapping("/{reservationId}")
+    public ResponseEntity<String> cancelReservation(@PathVariable Long reservationId, @RequestBody
+    CancelReservationReqDto reqDto) {
+        reservationService.cancelReservation(reservationId, reqDto);
+        return ResponseEntity.noContent().build();
+    }
+
+}
+

--- a/src/main/java/com/sayye/reservation/dto/CancelReservationReqDto.java
+++ b/src/main/java/com/sayye/reservation/dto/CancelReservationReqDto.java
@@ -1,0 +1,21 @@
+package com.sayye.reservation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CancelReservationReqDto {
+
+    @NotBlank(message = "이름은 필수입니다.")
+    @Size(min = 2, message = "이름은 최소 2글자 이상이어야 합니다.")
+    private String userName;
+
+    @NotBlank(message = "휴대폰 뒷자리는 필수입니다.")
+    @Pattern(regexp = "^[0-9]{4}$", message = "휴대폰 뒷번호는 4자리 숫자여야 합니다.")
+    private String phoneLastNumber;
+
+}

--- a/src/main/java/com/sayye/reservation/entity/Reservation.java
+++ b/src/main/java/com/sayye/reservation/entity/Reservation.java
@@ -48,4 +48,14 @@ public class Reservation {
 
     @Column(nullable = false)
     private LocalDate reservationDate;
+
+    public boolean isOwner(String userName, String phoneLastNumber) {
+        return this.userName.equals(userName) && this.phoneLastNumber.equals(phoneLastNumber);
+    }
+
+    public boolean isCancelable() {
+        LocalDateTime reservationDateTime = LocalDateTime.of(reservationDate, startTime);
+        // 현재 시간이 예약 시작 시간보다 1시간 전인지
+        return LocalDateTime.now().isBefore(reservationDateTime.minusHours(1));
+    }
 }

--- a/src/main/java/com/sayye/reservation/entity/Reservation.java
+++ b/src/main/java/com/sayye/reservation/entity/Reservation.java
@@ -4,6 +4,7 @@ import com.sayye.course.entity.Course;
 import com.sayye.room.entity.Room;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -25,11 +26,11 @@ public class Reservation {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "classes_id", nullable = false)
     private Course course;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "room_id", nullable = false)
     private Room room;
 

--- a/src/main/java/com/sayye/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/sayye/reservation/repository/ReservationRepository.java
@@ -1,0 +1,10 @@
+package com.sayye.reservation.repository;
+
+import com.sayye.reservation.entity.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+}

--- a/src/main/java/com/sayye/reservation/service/ReservationService.java
+++ b/src/main/java/com/sayye/reservation/service/ReservationService.java
@@ -1,0 +1,34 @@
+package com.sayye.reservation.service;
+
+import com.sayye.exception.ApiException;
+import com.sayye.exception.ErrorCode;
+import com.sayye.reservation.dto.CancelReservationReqDto;
+import com.sayye.reservation.entity.Reservation;
+import com.sayye.reservation.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class ReservationService {
+
+    private final ReservationRepository reservationRepository;
+
+    @Transactional
+    public void cancelReservation(Long reservationId, CancelReservationReqDto reqDto) {
+        Reservation reservation = reservationRepository.findById(reservationId)
+            .orElseThrow(() -> new ApiException(ErrorCode.RESERVATION_NOT_FOUND));
+
+        if (!reservation.isOwner(reqDto.getUserName(), reqDto.getPhoneLastNumber())) {
+            throw new ApiException(ErrorCode.RESERVATION_CANCEL_UNAUTHORIZED);
+        }
+
+        if (!reservation.isCancelable()) {
+            throw new ApiException(ErrorCode.RESERVATION_CANCEL_TIME_EXCEEDED);
+        }
+
+        reservationRepository.delete(reservation);
+    }
+}


### PR DESCRIPTION
### 작업 내용
* 예약 삭제(D) 기능 구현
     * 예약자가 예약을 취소할 수 있도록 예약 삭제 기능을 구현했습니다.
     * API 명세서 작성 시에는 예약 Id만 받도록 작성해뒀는데 해당 예약 Id에 저장된 예약자 정보와 현재 요청하는 요청자 정보가 일치하는지 검증하는 단계가 필요하다고 판단되어서 추가했습니다.
     * 취소 가능 시간(1시간)을 초과한 경우에는 취소할 수 없도록 처리했습니다.

* 예외 처리
     * 예약자 정보 불일치 : `RESERVED_CANCEL_UNAUTHORIZED`
     * 취소 가능 시간 초과 : `RESERVATION_CANCEL_TIME_EXCEEDED`

* 지연 로딩 적용
     * `Reservation` 엔티티 조회 시 연관된 `Room`, `Classes` 테이블을 불필요하게 JOIN하는 쿼리를 확인했고 `@ManyToOne` 관계를  `FetchType.LAZY`로 변경해 단건 조회 시 불필요한 쿼리가 발생하지 않도록 했습니다. 

* DELETE 요청 본문 사용
     * HTTP 스펙상 권장되지 않고 쿼리 파라미터로 전달하는 것이 권장되는 것 같은데 예약 취소에 필요한 데이터는 예약자의 정보이기 때문에 URL에 노출되지 않는 것이 맞다고 판단했습니다. 
     * 그래서 본문에 담는 방식을 선택했고 포스트맨으로 정상 동작하는 것을 확인했습니다.
     * DELETE보다 POST 요청이 맞다는 의견이 있다면 변경 예정입니다. 확인 후 의견주시면 감사하겠습니다.

<img width="874" height="387" alt="스크린샷 2025-11-30 오후 3 32 01" src="https://github.com/user-attachments/assets/46e28fa8-cb44-41a0-83bc-a02106939c87" />
<img width="872" height="411" alt="스크린샷 2025-11-30 오후 3 32 12" src="https://github.com/user-attachments/assets/1e83a5ad-a0fc-4b90-8b24-2f7841521e77" />
<img width="890" height="426" alt="스크린샷 2025-11-30 오후 3 32 29" src="https://github.com/user-attachments/assets/54040e0d-b03f-4033-bede-130a85a200d1" />
<img width="862" height="391" alt="스크린샷 2025-11-30 오후 3 32 56" src="https://github.com/user-attachments/assets/5f50a817-76b8-4f7c-8f61-2b43ca4aebd1" />
