### PR TITLE
16 fix 유효성 검증 추가

### DIFF
--- a/src/main/java/com/sayye/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sayye/exception/GlobalExceptionHandler.java
@@ -33,7 +33,9 @@ public class GlobalExceptionHandler {
             .stream()
             .collect(Collectors.toMap(
                 FieldError::getField, // 필드 이름을 key로
-                FieldError::getDefaultMessage // 기본 메시지를 value로 (validation에 작성한 메시지)
+                // 기본 메시지를 value로 (validation에 작성한 메시지)
+                // 중복 시 기존 메시지
+                FieldError::getDefaultMessage, (existingMsg, newMsg) -> existingMsg
             ));
 
         log.warn("Validation failed: {}", errors, e);

--- a/src/main/java/com/sayye/reservation/controller/ReservationController.java
+++ b/src/main/java/com/sayye/reservation/controller/ReservationController.java
@@ -2,6 +2,7 @@ package com.sayye.reservation.controller;
 
 import com.sayye.reservation.dto.CancelReservationReqDto;
 import com.sayye.reservation.service.ReservationService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -18,7 +19,7 @@ public class ReservationController {
     private final ReservationService reservationService;
 
     @DeleteMapping("/{reservationId}")
-    public ResponseEntity<String> cancelReservation(@PathVariable Long reservationId, @RequestBody
+    public ResponseEntity<String> cancelReservation(@PathVariable Long reservationId, @Valid @RequestBody
     CancelReservationReqDto reqDto) {
         reservationService.cancelReservation(reservationId, reqDto);
         return ResponseEntity.noContent().build();


### PR DESCRIPTION
### 작업 내용
* `@Valid` 어노테이션 추가
   * 기존 DTO에만 Validation 관련 설정을 해놓고 컨트롤러에는 추가하지 않았던 걸 발견해서 추가했습니다.

* GlobalExceptionHandler 로직 수정
   * 기존에 Map에 저장할 때 동일한 필드 이름의 key가 중복될 때의 처리를 따로 설정하지 않아서 포스트맨 응답에 에러 메시지가 잘 담기지 않는 현상을 발견했습니다.
   * 만약 동일한 필드에 에러가 하나 이상일 때 먼저 발생한 에러 메시지를 유지하도록 수정했습니다.

<img width="606" height="422" alt="스크린샷 2025-12-01 오전 10 08 20" src="https://github.com/user-attachments/assets/cadf9366-578d-4054-8980-5763a91b2a20" />
<img width="595" height="414" alt="스크린샷 2025-12-01 오전 10 08 38" src="https://github.com/user-attachments/assets/9779e290-a316-4ef2-8a4e-d7fc3a01fe9a" />
 