### PR TITLE
20 feat 예약 생성

### DIFF
--- a/src/main/java/com/sayye/exception/ErrorCode.java
+++ b/src/main/java/com/sayye/exception/ErrorCode.java
@@ -24,7 +24,11 @@ public enum ErrorCode {
     // 예약
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다."),
     RESERVATION_CANCEL_UNAUTHORIZED(HttpStatus.FORBIDDEN, "예약자 정보가 일치하지 않습니다."),
-    RESERVATION_CANCEL_TIME_EXCEEDED(HttpStatus.FORBIDDEN, "예약 시작 1시간 전에는 취소할 수 없습니다.");
+    RESERVATION_CANCEL_TIME_EXCEEDED(HttpStatus.FORBIDDEN, "예약 시작 1시간 전에는 취소할 수 없습니다."),
+    RESERVATION_INVALID_START_TIME(HttpStatus.BAD_REQUEST, "10시 전에는 예약을 할 수 없습니다."),
+    RESERVATION_EXCEED_MAX_DURATION(HttpStatus.BAD_REQUEST, "예약 이용 시간은 최대 2시간입니다."),
+    RESERVATION_USER_DUPLICATED(HttpStatus.CONFLICT, "해당 예약자 정보로 동일한 날짜에 예약이 존재합니다."),
+    RESERVATION_TIME_OVERLAPPED(HttpStatus.CONFLICT,"이미 예약되어있습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/sayye/reservation/controller/ReservationController.java
+++ b/src/main/java/com/sayye/reservation/controller/ReservationController.java
@@ -2,14 +2,18 @@ package com.sayye.reservation.controller;
 
 import com.sayye.reservation.dto.CancelReservationReqDto;
 import com.sayye.reservation.dto.ReservationAdminResDto;
+import com.sayye.reservation.dto.ReservationReqDto;
+import com.sayye.reservation.dto.ReservationResDto;
 import com.sayye.reservation.service.ReservationService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -37,6 +41,15 @@ public class ReservationController {
         int pageNumber = (page <= 0) ? 1 : page;
 
         return ResponseEntity.ok(reservationService.getAllReservations(pageNumber));
+    }
+
+    // Todo 예약자 예약 내역 조회 필요
+
+    @PostMapping("/{roomId}")
+    public ResponseEntity<ReservationResDto> createReservation(@PathVariable Long roomId,
+        @Valid @RequestBody ReservationReqDto reqDto) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(reservationService.createReservation(roomId, reqDto));
     }
 }
 

--- a/src/main/java/com/sayye/reservation/dto/ReservationReqDto.java
+++ b/src/main/java/com/sayye/reservation/dto/ReservationReqDto.java
@@ -1,0 +1,73 @@
+package com.sayye.reservation.dto;
+
+import com.sayye.course.entity.Course;
+import com.sayye.reservation.entity.Reservation;
+import com.sayye.room.entity.Room;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.Getter;
+
+@Getter
+public class ReservationReqDto {
+
+    @NotNull(message = "클래스 Id는 필수입니다.")
+    @Positive(message = "클래스 Id는 양수여야 합니다.")
+    private Long courseId;
+
+    @NotBlank(message = "이름은 필수입니다.")
+    @Size(min = 2, message = "이름은 최소 2글자 이상이어야 합니다.")
+    private String userName;
+
+    @NotBlank(message = "휴대폰 뒷자리는 필수입니다.")
+    @Pattern(regexp = "^[0-9]{4}$", message = "휴대폰 뒷번호는 4자리 숫자여야 합니다.")
+    private String phoneLastNumber;
+
+    @NotNull(message = "예약 시작 시간은 필수입니다.")
+    private LocalTime startTime;
+
+    @NotNull(message = "예약 종료 시간은 필수입니다.")
+    private LocalTime endTime;
+
+    @NotNull(message = "예약 날짜는 필수입니다.")
+    @FutureOrPresent(message = "과거 날짜는 선택할 수 없습니다.")
+    private LocalDate reservationDate;
+
+    // 스프링이 메서드 실행해서 검증해줌
+    @AssertTrue(message = "종료 시간은 시작 시간보다 늦어야 합니다.")
+    public boolean isTimeValid() {
+        if (startTime == null || endTime == null) {
+            return false;
+        }
+        return endTime.isAfter(startTime);
+    }
+
+    @AssertTrue(message = "이미 지난 시간은 예약할 수 없습니다.")
+    public boolean isFutureTime() {
+        if (startTime == null || endTime == null) {
+            return false;
+        }
+
+        LocalDate today = LocalDate.now();
+        LocalTime now = LocalTime.now();
+
+        // 날짜가 오늘이면
+        if (reservationDate.isEqual(today)) {
+            return startTime.isAfter(now); // 시작 시간이 지금 시간 이후여야 함 (과거 시간 불가)
+        }
+
+        return true;
+    }
+
+    public Reservation toEntity(Room room, Course course) {
+        return Reservation.of(room, course, userName, phoneLastNumber, startTime, endTime,
+            reservationDate);
+    }
+
+}

--- a/src/main/java/com/sayye/reservation/dto/ReservationResDto.java
+++ b/src/main/java/com/sayye/reservation/dto/ReservationResDto.java
@@ -1,0 +1,30 @@
+package com.sayye.reservation.dto;
+
+import com.sayye.reservation.entity.Reservation;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReservationResDto {
+
+    private Long id;
+    private String roomName;
+    private String userName;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private LocalDate reservationDate;
+
+    public static ReservationResDto from(Reservation reservation) {
+        return ReservationResDto.builder()
+            .id(reservation.getId())
+            .roomName(reservation.getRoom().getRoomName())
+            .userName(reservation.getUserName())
+            .startTime(reservation.getStartTime())
+            .endTime(reservation.getEndTime())
+            .reservationDate(reservation.getReservationDate())
+            .build();
+    }
+}

--- a/src/main/java/com/sayye/reservation/entity/Reservation.java
+++ b/src/main/java/com/sayye/reservation/entity/Reservation.java
@@ -18,6 +18,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -57,6 +58,34 @@ public class Reservation extends BaseEntity {
 
     @Column(nullable = false)
     private LocalDate reservationDate;
+
+    @Builder
+    private Reservation(Course course, Room room, String userName, String phoneLastNumber,
+        LocalTime startTime, LocalTime endTime, LocalDate reservationDate,
+        ReservationStatus status) {
+        this.course = course;
+        this.room = room;
+        this.userName = userName;
+        this.phoneLastNumber = phoneLastNumber;
+        this.status = status;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.reservationDate = reservationDate;
+    }
+
+    public static Reservation of(Room room, Course course, String userName, String phoneLastNumber,
+        LocalTime startTime, LocalTime endTime, LocalDate reservationDate) {
+        return Reservation.builder()
+            .course(course)
+            .room(room)
+            .userName(userName)
+            .phoneLastNumber(phoneLastNumber)
+            .startTime(startTime)
+            .status(ReservationStatus.RESERVED)
+            .endTime(endTime)
+            .reservationDate(reservationDate)
+            .build();
+    }
 
     public boolean isOwner(String userName, String phoneLastNumber) {
         return this.userName.equals(userName) && this.phoneLastNumber.equals(phoneLastNumber);

--- a/src/main/java/com/sayye/reservation/entity/Reservation.java
+++ b/src/main/java/com/sayye/reservation/entity/Reservation.java
@@ -59,7 +59,7 @@ public class Reservation extends BaseEntity {
     @Column(nullable = false)
     private LocalDate reservationDate;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private Reservation(Course course, Room room, String userName, String phoneLastNumber,
         LocalTime startTime, LocalTime endTime, LocalDate reservationDate,
         ReservationStatus status) {

--- a/src/main/java/com/sayye/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/sayye/reservation/repository/ReservationRepository.java
@@ -1,10 +1,15 @@
 package com.sayye.reservation.repository;
 
 import com.sayye.reservation.entity.Reservation;
+import com.sayye.reservation.entity.ReservationStatus;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -15,4 +20,20 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     @EntityGraph(attributePaths = {"room", "course"})
     Page<Reservation> findAll(Pageable pageable);
 
+    boolean existsByUserNameAndPhoneLastNumberAndReservationDateAndStatusNot(String userName,
+        String phoneLastNumber, LocalDate reservationDate, ReservationStatus status);
+
+    @Query("""
+            select count(r)
+            from  Reservation r
+            where r.room.id = :roomId
+            and r.reservationDate = :date
+            and r.status <> :cancelledStatus
+            and (r.startTime < :endTime and r.endTime > :startTime)
+        """)
+    Long existsOverlap(@Param("roomId") Long roomId,
+        @Param("date") LocalDate date,
+        @Param("startTime") LocalTime startTime,
+        @Param("endTime") LocalTime endTime,
+        @Param("cancelledStatus") ReservationStatus cancelledStatus);
 }

--- a/src/main/java/com/sayye/reservation/service/ReservationService.java
+++ b/src/main/java/com/sayye/reservation/service/ReservationService.java
@@ -1,11 +1,20 @@
 package com.sayye.reservation.service;
 
+import com.sayye.course.entity.Course;
+import com.sayye.course.repository.CourseRepository;
 import com.sayye.exception.ApiException;
 import com.sayye.exception.ErrorCode;
 import com.sayye.reservation.dto.CancelReservationReqDto;
-import com.sayye.reservation.entity.Reservation;
 import com.sayye.reservation.dto.ReservationAdminResDto;
+import com.sayye.reservation.dto.ReservationReqDto;
+import com.sayye.reservation.dto.ReservationResDto;
+import com.sayye.reservation.entity.Reservation;
+import com.sayye.reservation.entity.ReservationStatus;
 import com.sayye.reservation.repository.ReservationRepository;
+import com.sayye.room.entity.Room;
+import com.sayye.room.repository.RoomRepository;
+import java.time.Duration;
+import java.time.LocalTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -24,6 +33,10 @@ public class ReservationService {
     private static final String SORT_BY = "createdAt";
 
     private final ReservationRepository reservationRepository;
+
+    // Todo service 구현 완료 시 변경 필요
+    private final RoomRepository roomRepository;
+    private final CourseRepository courseRepository;
 
     @Transactional
     public void cancelReservation(Long reservationId, CancelReservationReqDto reqDto) {
@@ -46,5 +59,52 @@ public class ReservationService {
             Sort.by(Direction.DESC, SORT_BY));
 
         return reservationRepository.findAll(pageable).map(ReservationAdminResDto::from);
+    }
+
+    @Transactional
+    public ReservationResDto createReservation(Long roomId, ReservationReqDto reqDto) {
+        // 예약 시작 시간이 10시 전이면
+        validateReservationTime(reqDto.getStartTime(), reqDto.getEndTime());
+
+        // Todo 회의실 존재 여부 검증
+        Room room = roomRepository.findById(roomId).orElseThrow(() -> new RuntimeException());
+
+        // Todo 클래스 존재 여부 검증
+        Course course = courseRepository.findById(1L).orElseThrow(() -> new RuntimeException());
+
+        // 해당 예약자가 예약 날짜에 이미 예약 했다면
+        boolean alreadyReserved = reservationRepository.existsByUserNameAndPhoneLastNumberAndReservationDateAndStatusNot(
+            reqDto.getUserName(),
+            reqDto.getPhoneLastNumber(),
+            reqDto.getReservationDate(),
+            ReservationStatus.CANCELED
+        );
+
+        if (alreadyReserved) {
+            throw new ApiException(ErrorCode.RESERVATION_USER_DUPLICATED);
+        }
+
+        // 예약자가 예약한 시간에 이미 예약 되어 있다면
+        if (reservationRepository.existsOverlap(roomId, reqDto.getReservationDate(),
+            reqDto.getStartTime(), reqDto.getEndTime(), ReservationStatus.CANCELED) > 0) {
+            throw new ApiException(ErrorCode.RESERVATION_TIME_OVERLAPPED);
+        }
+
+        Reservation saved = reservationRepository.save(reqDto.toEntity(room, course));
+        return ReservationResDto.from(saved);
+
+    }
+
+    private void validateReservationTime(LocalTime startTime, LocalTime endTime) {
+        // 예약 시작 시간이 10시 전이면
+        if (startTime.isBefore(LocalTime.of(10, 0))) {
+            throw new ApiException(ErrorCode.RESERVATION_INVALID_START_TIME);
+        }
+
+        // 이용 시간이 2시간 이상이면
+        long durationMinutes = Duration.between(startTime, endTime).toMinutes();
+        if (durationMinutes > 120) {
+            throw new ApiException(ErrorCode.RESERVATION_EXCEED_MAX_DURATION);
+        }
     }
 }


### PR DESCRIPTION
### 작업 내용
* 예약 생성 기능을 구현했습니다.
    * dto의 메서드에 `@AssertTrue` 어노테이션을 붙이면 스프링이 매개변수로 바인딩할 때 해당 메서드를 실행시켜서 결과가 `true`인 것만 바인딩 처리해준다고 해서 이번에 처음 사용해봤습니다.
       * 해당 부분을 엔티티나 서비스 단에서도 처리해주면 더 좋을 것 같은데 우선 시간이 없어서 dto에서만 검증하도록 했습니다.
   * 하루 1회 예약 가능한 부분과 최대 2시간 이상은 예약 불가한 점, 10시 이전에는 예약할 수 없는 점 적용했습니다.
   * 엔티티가 생성될 때 생성자에서 `RESERVED` 값을 상태로 넣어주도록 해서 외부에서는 별도로 설정할 수 없도록 했습니다.
   * 엔티티 생성 시 정적 팩토리 메서드 (`of`) 내부에서 `private` 생성자를 호출하도록 해 외부에서의 생성자 호출을 최대한 막았습니다.
* 지금은 Room, Course 코드 구현이 안 되어 있어서 우선 리포지토리 활용했습니다. 각 서비스 구현되면 해당 코드는 수정 예정입니다.
<img width="917" height="490" alt="스크린샷 2025-12-05 오후 4 39 57" src="https://github.com/user-attachments/assets/bb0e97c4-27b4-4f28-9a76-42c35756eaa6" />
<img width="910" height="392" alt="스크린샷 2025-12-05 오후 4 41 24" src="https://github.com/user-attachments/assets/ee94a266-582a-47c3-8b0e-78f8dba98538" />
<img width="911" height="432" alt="스크린샷 2025-12-05 오후 4 41 55" src="https://github.com/user-attachments/assets/0a65e647-744f-48ca-b306-18d28f1c3777" />
<img width="906" height="429" alt="스크린샷 2025-12-05 오후 4 42 15" src="https://github.com/user-attachments/assets/1ecff1c5-f4ac-455d-9092-e0cab2852e6e" />
<img width="901" height="404" alt="스크린샷 2025-12-05 오후 4 42 34" src="https://github.com/user-attachments/assets/feebd5f4-b3b3-4f08-9ef5-90941f8bf8e6" />
<img width="901" height="422" alt="스크린샷 2025-12-05 오후 5 40 53" src="https://github.com/user-attachments/assets/85180859-e409-4676-a0a1-15f08bc7cf2b" />
