### PR TITLE
29 feat 예약 수정

### DIFF
--- a/src/main/java/com/sayye/exception/ErrorCode.java
+++ b/src/main/java/com/sayye/exception/ErrorCode.java
@@ -23,8 +23,8 @@ public enum ErrorCode {
 
     // 예약
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다."),
-    RESERVATION_CANCEL_UNAUTHORIZED(HttpStatus.FORBIDDEN, "예약자 정보가 일치하지 않습니다."),
-    RESERVATION_CANCEL_TIME_EXCEEDED(HttpStatus.FORBIDDEN, "예약 시작 1시간 전에는 취소할 수 없습니다."),
+    RESERVATION_UNAUTHORIZED(HttpStatus.FORBIDDEN, "예약자 정보가 일치하지 않습니다."),
+    RESERVATION_TIME_LIMIT_EXCEEDED(HttpStatus.FORBIDDEN, "예약 시작 1시간 전에는 취소/변경할 수 없습니다."),
     RESERVATION_INVALID_START_TIME(HttpStatus.BAD_REQUEST, "10시 전에는 예약을 할 수 없습니다."),
     RESERVATION_EXCEED_MAX_DURATION(HttpStatus.BAD_REQUEST, "예약 이용 시간은 최대 2시간입니다."),
     RESERVATION_USER_DUPLICATED(HttpStatus.CONFLICT, "해당 예약자 정보로 동일한 날짜에 예약이 존재합니다."),

--- a/src/main/java/com/sayye/reservation/controller/ReservationController.java
+++ b/src/main/java/com/sayye/reservation/controller/ReservationController.java
@@ -1,9 +1,10 @@
 package com.sayye.reservation.controller;
 
-import com.sayye.reservation.dto.CancelReservationReqDto;
-import com.sayye.reservation.dto.ReservationAdminResDto;
-import com.sayye.reservation.dto.ReservationReqDto;
-import com.sayye.reservation.dto.ReservationResDto;
+import com.sayye.reservation.dto.request.CancelReservationReqDto;
+import com.sayye.reservation.dto.request.ReservationReqDto;
+import com.sayye.reservation.dto.request.UpdateReservationReqDto;
+import com.sayye.reservation.dto.response.ReservationAdminResDto;
+import com.sayye.reservation.dto.response.ReservationResDto;
 import com.sayye.reservation.service.ReservationService;
 import jakarta.validation.Valid;
 import java.time.LocalDate;
@@ -14,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -30,8 +32,7 @@ public class ReservationController {
 
     @DeleteMapping("/{reservationId}")
     public ResponseEntity<String> cancelReservation(@PathVariable Long reservationId,
-        @Valid @RequestBody
-        CancelReservationReqDto reqDto) {
+        @Valid @RequestBody CancelReservationReqDto reqDto) {
         reservationService.cancelReservation(reservationId, reqDto);
         return ResponseEntity.noContent().build();
     }
@@ -58,7 +59,16 @@ public class ReservationController {
     @GetMapping("/{roomId}")
     public ResponseEntity<List<ReservationResDto>> getReservationsByRoomId(
         @PathVariable Long roomId, @RequestParam LocalDate reservationDate) {
-        return ResponseEntity.ok(reservationService.getReservationsByRoomId(roomId, reservationDate));
+        return ResponseEntity.ok(
+            reservationService.getReservationsByRoomId(roomId, reservationDate));
     }
+
+    @PatchMapping("/{reservationId}")
+    public ResponseEntity<ReservationResDto> updateReservation(@PathVariable Long reservationId,
+        @Valid @RequestBody UpdateReservationReqDto reqDto) {
+        return ResponseEntity.ok(reservationService.updateReservation(reservationId, reqDto));
+    }
+
+
 }
 

--- a/src/main/java/com/sayye/reservation/dto/request/CancelReservationReqDto.java
+++ b/src/main/java/com/sayye/reservation/dto/request/CancelReservationReqDto.java
@@ -1,4 +1,4 @@
-package com.sayye.reservation.dto;
+package com.sayye.reservation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;

--- a/src/main/java/com/sayye/reservation/dto/request/ReservationReqDto.java
+++ b/src/main/java/com/sayye/reservation/dto/request/ReservationReqDto.java
@@ -1,4 +1,4 @@
-package com.sayye.reservation.dto;
+package com.sayye.reservation.dto.request;
 
 import com.sayye.course.entity.Course;
 import com.sayye.reservation.entity.Reservation;

--- a/src/main/java/com/sayye/reservation/dto/request/UpdateReservationReqDto.java
+++ b/src/main/java/com/sayye/reservation/dto/request/UpdateReservationReqDto.java
@@ -1,0 +1,63 @@
+package com.sayye.reservation.dto.request;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UpdateReservationReqDto {
+
+    @NotBlank(message = "이름은 필수입니다.")
+    @Size(min = 2, message = "이름은 최소 2글자 이상이어야 합니다.")
+    private String userName;
+
+    @NotBlank(message = "휴대폰 뒷자리는 필수입니다.")
+    @Pattern(regexp = "^[0-9]{4}$", message = "휴대폰 뒷번호는 4자리 숫자여야 합니다.")
+    private String phoneLastNumber;
+
+    @NotNull(message = "예약 시작 시간은 필수입니다.")
+    private LocalTime startTime;
+
+    @NotNull(message = "예약 종료 시간은 필수입니다.")
+    private LocalTime endTime;
+
+    @NotNull(message = "예약 날짜는 필수입니다.")
+    @FutureOrPresent(message = "과거 날짜는 선택할 수 없습니다.")
+    private LocalDate reservationDate;
+
+    @AssertTrue(message = "종료 시간은 시작 시간보다 늦어야 합니다.")
+    public boolean isTimeValid() {
+        if (startTime == null || endTime == null) {
+            return false;
+        }
+        return endTime.isAfter(startTime);
+    }
+
+    @AssertTrue(message = "이미 지난 시간은 예약할 수 없습니다.")
+    public boolean isFutureTime() {
+        if (startTime == null || endTime == null) {
+            return false;
+        }
+
+        LocalDate today = LocalDate.now();
+        LocalTime now = LocalTime.now();
+
+        // 날짜가 오늘이면
+        if (reservationDate.isEqual(today)) {
+            return startTime.isAfter(now); // 시작 시간이 지금 시간 이후여야 함 (과거 시간 불가)
+        }
+
+        return true;
+    }
+
+
+}

--- a/src/main/java/com/sayye/reservation/dto/response/ReservationAdminResDto.java
+++ b/src/main/java/com/sayye/reservation/dto/response/ReservationAdminResDto.java
@@ -1,4 +1,4 @@
-package com.sayye.reservation.dto;
+package com.sayye.reservation.dto.response;
 
 import com.sayye.reservation.entity.Reservation;
 import java.time.LocalDate;

--- a/src/main/java/com/sayye/reservation/dto/response/ReservationResDto.java
+++ b/src/main/java/com/sayye/reservation/dto/response/ReservationResDto.java
@@ -1,4 +1,4 @@
-package com.sayye.reservation.dto;
+package com.sayye.reservation.dto.response;
 
 import com.sayye.reservation.entity.Reservation;
 import java.time.LocalDate;

--- a/src/main/java/com/sayye/reservation/entity/Reservation.java
+++ b/src/main/java/com/sayye/reservation/entity/Reservation.java
@@ -87,14 +87,23 @@ public class Reservation extends BaseEntity {
             .build();
     }
 
+    public void updateReservationTime(LocalTime startTime, LocalTime endTime, LocalDate reservationDate) {
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.reservationDate = reservationDate;
+    }
+
     public boolean isOwner(String userName, String phoneLastNumber) {
         return this.userName.equals(userName) && this.phoneLastNumber.equals(phoneLastNumber);
     }
 
-    // Todo 파라미터 시간
-    public boolean isCancelable() {
+    public boolean isModifiable(LocalDateTime now) {
         LocalDateTime reservationDateTime = LocalDateTime.of(reservationDate, startTime);
         // 현재 시간이 예약 시작 시간보다 1시간 전인지
-        return LocalDateTime.now().isBefore(reservationDateTime.minusHours(1));
+        return now.isBefore(reservationDateTime.minusHours(1));
+    }
+
+    public boolean isDateChanged(LocalDate newDate) {
+        return !this.reservationDate.equals(newDate);
     }
 }

--- a/src/main/java/com/sayye/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/sayye/reservation/repository/ReservationRepository.java
@@ -31,10 +31,12 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             and r.reservationDate = :date
             and r.status <> :cancelledStatus
             and (r.startTime < :endTime and r.endTime > :startTime)
+            and (:excludeId is null or r.id <> :roomId)
         """)
     Long existsOverlap(@Param("roomId") Long roomId, @Param("date") LocalDate date,
         @Param("startTime") LocalTime startTime, @Param("endTime") LocalTime endTime,
-        @Param("cancelledStatus") ReservationStatus cancelledStatus);
+        @Param("cancelledStatus") ReservationStatus cancelledStatus,
+        @Param("excludeId") Long excludeId);
 
     List<Reservation> findAllByRoomIdAndReservationDateAndStatusNotOrderByStartTimeAsc(Long roomId,
         LocalDate date, ReservationStatus status);

--- a/src/main/java/com/sayye/reservation/service/ReservationService.java
+++ b/src/main/java/com/sayye/reservation/service/ReservationService.java
@@ -4,17 +4,19 @@ import com.sayye.course.entity.Course;
 import com.sayye.course.repository.CourseRepository;
 import com.sayye.exception.ApiException;
 import com.sayye.exception.ErrorCode;
-import com.sayye.reservation.dto.CancelReservationReqDto;
-import com.sayye.reservation.dto.ReservationAdminResDto;
-import com.sayye.reservation.dto.ReservationReqDto;
-import com.sayye.reservation.dto.ReservationResDto;
+import com.sayye.reservation.dto.request.CancelReservationReqDto;
+import com.sayye.reservation.dto.request.ReservationReqDto;
+import com.sayye.reservation.dto.request.UpdateReservationReqDto;
+import com.sayye.reservation.dto.response.ReservationAdminResDto;
+import com.sayye.reservation.dto.response.ReservationResDto;
 import com.sayye.reservation.entity.Reservation;
 import com.sayye.reservation.entity.ReservationStatus;
 import com.sayye.reservation.repository.ReservationRepository;
+import com.sayye.room.RoomRepository;
 import com.sayye.room.entity.Room;
-import com.sayye.room.repository.RoomRepository;
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -42,16 +44,10 @@ public class ReservationService {
 
     @Transactional
     public void cancelReservation(Long reservationId, CancelReservationReqDto reqDto) {
-        Reservation reservation = reservationRepository.findById(reservationId)
-            .orElseThrow(() -> new ApiException(ErrorCode.RESERVATION_NOT_FOUND));
+        Reservation reservation = findReservation(reservationId);
 
-        if (!reservation.isOwner(reqDto.getUserName(), reqDto.getPhoneLastNumber())) {
-            throw new ApiException(ErrorCode.RESERVATION_CANCEL_UNAUTHORIZED);
-        }
-
-        if (!reservation.isCancelable()) {
-            throw new ApiException(ErrorCode.RESERVATION_CANCEL_TIME_EXCEEDED);
-        }
+        validateOwner(reservation, reqDto.getUserName(), reqDto.getPhoneLastNumber());
+        validateModifiableTime(reservation);
 
         reservationRepository.delete(reservation);
     }
@@ -75,23 +71,13 @@ public class ReservationService {
         Course course = courseRepository.findById(1L).orElseThrow(() -> new RuntimeException());
 
         // 해당 예약자가 예약 날짜에 이미 예약 했다면
-        boolean alreadyReserved = reservationRepository.existsByUserNameAndPhoneLastNumberAndReservationDateAndStatusNot(
-            reqDto.getUserName(),
-            reqDto.getPhoneLastNumber(),
-            reqDto.getReservationDate(),
-            ReservationStatus.CANCELED
-        );
-
-        if (alreadyReserved) {
-            throw new ApiException(ErrorCode.RESERVATION_USER_DUPLICATED);
-        }
+        validateDuplicateUser(reqDto.getUserName(), reqDto.getPhoneLastNumber(),
+            reqDto.getReservationDate());
 
         // 예약자가 예약한 시간에 이미 예약 되어 있다면
         // Todo room.getId로 수정 필요
-        if (reservationRepository.existsOverlap(roomId, reqDto.getReservationDate(),
-            reqDto.getStartTime(), reqDto.getEndTime(), ReservationStatus.CANCELED) > 0) {
-            throw new ApiException(ErrorCode.RESERVATION_TIME_OVERLAPPED);
-        }
+        validateOverlap(room.getId(), reqDto.getReservationDate(), reqDto.getStartTime(),
+            reqDto.getEndTime(), null);
 
         Reservation saved = reservationRepository.save(reqDto.toEntity(room, course));
         return ReservationResDto.from(saved);
@@ -111,6 +97,73 @@ public class ReservationService {
 
     }
 
+    @Transactional
+    public ReservationResDto updateReservation(Long reservationId, UpdateReservationReqDto reqDto) {
+        Reservation reservation = findReservation(reservationId);
+
+        validateOwner(reservation, reqDto.getUserName(), reqDto.getPhoneLastNumber());
+
+        validateModifiableTime(reservation);
+
+        validateReservationTime(reqDto.getStartTime(), reqDto.getEndTime());
+
+        // 날짜가 바뀌었을 때만 이미 예약한 내역이 있는지 검증
+        if (reservation.isDateChanged(reqDto.getReservationDate())) {
+            validateDuplicateUser(reqDto.getUserName(), reqDto.getPhoneLastNumber(),
+                reqDto.getReservationDate());
+        }
+
+        validateOverlap(reservation.getRoom().getId(), reqDto.getReservationDate(),
+            reqDto.getStartTime(), reqDto.getEndTime(), reservationId);
+
+        reservation.updateReservationTime(reqDto.getStartTime(), reqDto.getEndTime(),
+            reqDto.getReservationDate());
+
+        return ReservationResDto.from(reservation);
+    }
+
+    private Reservation findReservation(Long reservationId) {
+        return reservationRepository.findById(reservationId)
+            .orElseThrow(() -> new ApiException(ErrorCode.RESERVATION_NOT_FOUND));
+    }
+
+    // 예약자 일치 여부
+    private void validateOwner(Reservation reservation, String userName, String phoneLastNumber) {
+        if (!reservation.isOwner(userName, phoneLastNumber)) {
+            throw new ApiException(ErrorCode.RESERVATION_UNAUTHORIZED);
+        }
+    }
+
+    // 취소/변경 가능 시간 여부
+    private void validateModifiableTime(Reservation reservation) {
+        if (!reservation.isModifiable(LocalDateTime.now())) {
+            throw new ApiException(ErrorCode.RESERVATION_TIME_LIMIT_EXCEEDED);
+        }
+    }
+
+    private void validateDuplicateUser(String userName, String phone, LocalDate date) {
+        boolean alreadyReserved = reservationRepository.existsByUserNameAndPhoneLastNumberAndReservationDateAndStatusNot(
+            userName,
+            phone,
+            date,
+            ReservationStatus.CANCELED
+        );
+
+        if (alreadyReserved) {
+            throw new ApiException(ErrorCode.RESERVATION_USER_DUPLICATED);
+        }
+
+    }
+
+    private void validateOverlap(Long roomId, LocalDate reservationDate, LocalTime startTime,
+        LocalTime endTime, Long excludeId) {
+        if (reservationRepository.existsOverlap(roomId, reservationDate, startTime, endTime,
+            ReservationStatus.CANCELED, excludeId) > 0) {
+            throw new ApiException(ErrorCode.RESERVATION_TIME_OVERLAPPED);
+        }
+    }
+
+    // 예약 시 검증
     private void validateReservationTime(LocalTime startTime, LocalTime endTime) {
         // 예약 시작 시간이 10시 전이면
         if (startTime.isBefore(LocalTime.of(10, 0))) {


### PR DESCRIPTION
### 작업 내용
* 예약 시간 변경 기능을 구현했습니다.
   * 예약 생성 시 사용했던 검증 로직을 최대한 재활용했습니다.
   * 예약 날짜 수정이 아닌 경우에는 어차피 1일 1예약 규칙을 지키고 있다는 거니까 날짜가 변경되었을 때만 db 조회하도록 했습니다.
   * 서비스의 각 메서드에서 두번 이상 호출되는 로직은 `private` 메서드로 추출해 호출하여 사용할 수 있도록 변경했습니다.
* 객체지향적인 코드를 위해 `entity.getXXX()`으로 가져와서 검증해야 하는 로직들은 최대한 Entity 객체에 위임했습니다.
   * 해당 내용에 대해서는 ["Tell,Dont ask" 원칙](https://martinfowler.com/bliki/TellDontAsk.html) 한번 읽어보시면 좋을 것 같습니다.
