### PR TITLE
31 feat 예약 전체 및 단일 조회

### DIFF
--- a/src/main/java/com/sayye/reservation/controller/ReservationController.java
+++ b/src/main/java/com/sayye/reservation/controller/ReservationController.java
@@ -1,6 +1,7 @@
 package com.sayye.reservation.controller;
 
 import com.sayye.reservation.dto.request.CancelReservationReqDto;
+import com.sayye.reservation.dto.request.ReadReservationReqDto;
 import com.sayye.reservation.dto.request.ReservationReqDto;
 import com.sayye.reservation.dto.request.UpdateReservationReqDto;
 import com.sayye.reservation.dto.response.ReservationAdminResDto;
@@ -39,15 +40,26 @@ public class ReservationController {
 
     // 관리자 조회용
     @GetMapping
-    public ResponseEntity<Page<ReservationAdminResDto>> getAllReservations(
+    public ResponseEntity<Page<ReservationAdminResDto>> getAllReservationsForAdmin(
         @RequestParam(defaultValue = "1") int page) {
         int pageNumber = (page <= 0) ? 1 : page;
 
-        return ResponseEntity.ok(reservationService.getAllReservations(pageNumber));
+        return ResponseEntity.ok(reservationService.getAllReservationsForAdmin(pageNumber));
     }
 
-    // Todo 예약자 예약 내역 조회 필요
+    @PostMapping
+    public ResponseEntity<List<ReservationResDto>> getAllReservations(
+        @Valid @RequestBody ReadReservationReqDto reqDto) {
+        return ResponseEntity.ok(reservationService.getAllReservations(reqDto));
+    }
 
+    @PostMapping("/{reservationId}")
+    public ResponseEntity<ReservationResDto> getReservationDetail(
+        @PathVariable Long reservationId, @Valid @RequestBody ReadReservationReqDto reqDto) {
+        return ResponseEntity.ok(reservationService.getReservationDetail(reservationId, reqDto));
+    }
+
+    // Todo RoomController로 이동 필요할듯 (/rooms/{roomId}/reservations)
     @PostMapping("/{roomId}")
     public ResponseEntity<ReservationResDto> createReservation(@PathVariable Long roomId,
         @Valid @RequestBody ReservationReqDto reqDto) {

--- a/src/main/java/com/sayye/reservation/dto/request/ReadReservationReqDto.java
+++ b/src/main/java/com/sayye/reservation/dto/request/ReadReservationReqDto.java
@@ -1,0 +1,18 @@
+package com.sayye.reservation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class ReadReservationReqDto {
+    @NotBlank(message = "이름은 필수입니다.")
+    @Size(min = 2, message = "이름은 최소 2글자 이상이어야 합니다.")
+    private String userName;
+
+    @NotBlank(message = "휴대폰 뒷자리는 필수입니다.")
+    @Pattern(regexp = "^[0-9]{4}$", message = "휴대폰 뒷번호는 4자리 숫자여야 합니다.")
+    private String phoneLastNumber;
+
+}

--- a/src/main/java/com/sayye/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/sayye/reservation/repository/ReservationRepository.java
@@ -40,4 +40,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     List<Reservation> findAllByRoomIdAndReservationDateAndStatusNotOrderByStartTimeAsc(Long roomId,
         LocalDate date, ReservationStatus status);
+
+    List<Reservation> findByUserNameAndPhoneLastNumberOrderByCreatedAtDesc(String userName,
+        String phoneLastNumber);
 }

--- a/src/main/java/com/sayye/reservation/service/ReservationService.java
+++ b/src/main/java/com/sayye/reservation/service/ReservationService.java
@@ -5,6 +5,7 @@ import com.sayye.course.repository.CourseRepository;
 import com.sayye.exception.ApiException;
 import com.sayye.exception.ErrorCode;
 import com.sayye.reservation.dto.request.CancelReservationReqDto;
+import com.sayye.reservation.dto.request.ReadReservationReqDto;
 import com.sayye.reservation.dto.request.ReservationReqDto;
 import com.sayye.reservation.dto.request.UpdateReservationReqDto;
 import com.sayye.reservation.dto.response.ReservationAdminResDto;
@@ -12,8 +13,8 @@ import com.sayye.reservation.dto.response.ReservationResDto;
 import com.sayye.reservation.entity.Reservation;
 import com.sayye.reservation.entity.ReservationStatus;
 import com.sayye.reservation.repository.ReservationRepository;
-import com.sayye.room.RoomRepository;
 import com.sayye.room.entity.Room;
+import com.sayye.room.repository.RoomRepository;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -52,12 +53,27 @@ public class ReservationService {
         reservationRepository.delete(reservation);
     }
 
-    public Page<ReservationAdminResDto> getAllReservations(int page) {
+    public Page<ReservationAdminResDto> getAllReservationsForAdmin(int page) {
         Pageable pageable = PageRequest.of(page - 1, DEFAULT_SIZE,
             Sort.by(Direction.DESC, SORT_BY));
 
         return reservationRepository.findAll(pageable).map(ReservationAdminResDto::from);
     }
+
+    public List<ReservationResDto> getAllReservations(ReadReservationReqDto reqDto) {
+        List<Reservation> reservations = reservationRepository.findByUserNameAndPhoneLastNumberOrderByCreatedAtDesc(
+            reqDto.getUserName(), reqDto.getPhoneLastNumber());
+        return reservations.stream().map(ReservationResDto::from).toList();
+    }
+
+    public ReservationResDto getReservationDetail(Long reservationId, ReadReservationReqDto reqDto) {
+        Reservation reservation = reservationRepository.findById(reservationId)
+            .orElseThrow(() -> new ApiException(ErrorCode.RESERVATION_NOT_FOUND));
+
+        validateOwner(reservation, reqDto.getUserName(), reqDto.getPhoneLastNumber());
+        return ReservationResDto.from(reservation);
+    }
+
 
     @Transactional
     public ReservationResDto createReservation(Long roomId, ReservationReqDto reqDto) {


### PR DESCRIPTION
### 작업 내용
* 수강생용 예약 전체 조회 및 단일 조회를 구현했습니다.
   * 예약자 이름과 휴대폰번호를 받아야 해서 `Post` 요청으로 받아서 요청 본문으로 데이터를 받아 예약자 일치 여부를 검증하도록 구현했습니다. (단일 조회)

* 수강생용 메서드가 추가되어 구분을 위해 관리자 메서드명을 수정했습니다. (`getAllReservations` -> `getAllReservationsForAdmin`)

* 수강생용 예약 단일 조회 (`@PostMapping("/{reservationId}")` )와 예약 생성 (`@PostMapping("/{roomId}")`)의 Path가 겹쳐서 이부분은 추후 `RoomController`로 이동 필요할 것 같습니다.