### PR TITLE
46 feat 관리자 예약 기능 추가

### DIFF
--- a/src/main/java/com/sayye/admin/controller/AdminController.java
+++ b/src/main/java/com/sayye/admin/controller/AdminController.java
@@ -69,7 +69,7 @@ public class AdminController {
     }
 
     @PostMapping("/rooms/{roomId}/reservations")
-    public ResponseEntity<ReservationResDto> blockRoomTime(@PathVariable Long roomId,
+    public ResponseEntity<ReservationResDto> createAdminReservation(@PathVariable Long roomId,
         @Valid @RequestBody AdminReservationReqDto reqDto, Authentication authentication) {
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(adminReservationService.createAdminReservation(roomId, reqDto, authentication.getName()));

--- a/src/main/java/com/sayye/admin/controller/AdminController.java
+++ b/src/main/java/com/sayye/admin/controller/AdminController.java
@@ -3,19 +3,24 @@ package com.sayye.admin.controller;
 import com.sayye.admin.dto.request.UpdatePasswordRequest;
 import com.sayye.admin.dto.response.AdminResponse;
 import com.sayye.admin.service.AdminService;
+import com.sayye.reservation.dto.request.AdminReservationReqDto;
+import com.sayye.reservation.dto.response.ReservationResDto;
+import com.sayye.reservation.service.AdminReservationService;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.DeleteMapping;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,6 +28,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 public class AdminController {
 
     private final AdminService adminService;
+    private final AdminReservationService adminReservationService;
 
     // 관리자 전체 조회 - MASTER만 가능
     @PreAuthorize("hasRole('MASTER')")
@@ -60,6 +66,13 @@ public class AdminController {
     ) {
         adminService.delete(userId);
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/rooms/{roomId}/reservations")
+    public ResponseEntity<ReservationResDto> blockRoomTime(@PathVariable Long roomId,
+        @Valid @RequestBody AdminReservationReqDto reqDto, Authentication authentication) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(adminReservationService.createAdminReservation(roomId, reqDto, authentication.getName()));
     }
 
 }

--- a/src/main/java/com/sayye/exception/ErrorCode.java
+++ b/src/main/java/com/sayye/exception/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode {
     RESERVATION_UNAUTHORIZED(HttpStatus.FORBIDDEN, "예약자 정보가 일치하지 않습니다."),
     RESERVATION_TIME_LIMIT_EXCEEDED(HttpStatus.FORBIDDEN, "예약 시작 1시간 전에는 취소/변경할 수 없습니다."),
     RESERVATION_INVALID_START_TIME(HttpStatus.BAD_REQUEST, "10시 전에는 예약을 할 수 없습니다."),
+    RESERVATION_SYSTEM_NOT_OPEN_YET(HttpStatus.BAD_REQUEST, "예약은 오전 10시부터 가능합니다."),
     RESERVATION_EXCEED_MAX_DURATION(HttpStatus.BAD_REQUEST, "예약 이용 시간은 최대 2시간입니다."),
     RESERVATION_USER_DUPLICATED(HttpStatus.CONFLICT, "해당 예약자 정보로 동일한 날짜에 예약이 존재합니다."),
     RESERVATION_TIME_OVERLAPPED(HttpStatus.CONFLICT,"이미 예약되어있습니다.");

--- a/src/main/java/com/sayye/reservation/dto/request/AdminReservationReqDto.java
+++ b/src/main/java/com/sayye/reservation/dto/request/AdminReservationReqDto.java
@@ -10,7 +10,7 @@ import java.time.LocalTime;
 import lombok.Getter;
 
 @Getter
-public class BlockReqDto {
+public class AdminReservationReqDto {
 
     @NotNull(message = "예약 시작 시간은 필수입니다.")
     private LocalTime startTime;
@@ -48,7 +48,7 @@ public class BlockReqDto {
     }
 
     public Reservation toEntity(Room room, String adminId) {
-        return Reservation.block(room, adminId, startTime, endTime, reservationDate);
+        return Reservation.createByAdmin(room, adminId, startTime, endTime, reservationDate);
     }
 
 }

--- a/src/main/java/com/sayye/reservation/dto/request/BlockReqDto.java
+++ b/src/main/java/com/sayye/reservation/dto/request/BlockReqDto.java
@@ -1,0 +1,54 @@
+package com.sayye.reservation.dto.request;
+
+import com.sayye.reservation.entity.Reservation;
+import com.sayye.room.entity.Room;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.Getter;
+
+@Getter
+public class BlockReqDto {
+
+    @NotNull(message = "예약 시작 시간은 필수입니다.")
+    private LocalTime startTime;
+
+    @NotNull(message = "예약 종료 시간은 필수입니다.")
+    private LocalTime endTime;
+
+    @NotNull(message = "예약 날짜는 필수입니다.")
+    @FutureOrPresent(message = "과거 날짜는 선택할 수 없습니다.")
+    private LocalDate reservationDate;
+
+    @AssertTrue(message = "종료 시간은 시작 시간보다 늦어야 합니다.")
+    public boolean isTimeValid() {
+        if (startTime == null || endTime == null) {
+            return false;
+        }
+        return endTime.isAfter(startTime);
+    }
+
+    @AssertTrue(message = "이미 지난 시간은 예약할 수 없습니다.")
+    public boolean isFutureTime() {
+        if (startTime == null || endTime == null) {
+            return false;
+        }
+
+        LocalDate today = LocalDate.now();
+        LocalTime now = LocalTime.now();
+
+        // 날짜가 오늘이면
+        if (reservationDate.isEqual(today)) {
+            return startTime.isAfter(now); // 시작 시간이 지금 시간 이후여야 함 (과거 시간 불가)
+        }
+
+        return true;
+    }
+
+    public Reservation toEntity(Room room, String adminId) {
+        return Reservation.block(room, adminId, startTime, endTime, reservationDate);
+    }
+
+}

--- a/src/main/java/com/sayye/reservation/entity/Reservation.java
+++ b/src/main/java/com/sayye/reservation/entity/Reservation.java
@@ -87,7 +87,7 @@ public class Reservation extends BaseEntity {
             .build();
     }
 
-    public static Reservation block(Room room, String userName, LocalTime startTime, LocalTime endTime, LocalDate reservationDate) {
+    public static Reservation createByAdmin(Room room, String userName, LocalTime startTime, LocalTime endTime, LocalDate reservationDate) {
         return Reservation.builder()
             .room(room)
             .userName(userName)
@@ -106,6 +106,10 @@ public class Reservation extends BaseEntity {
 
     public void cancel() {
         this.status = ReservationStatus.CANCELED;
+    }
+
+    public void cancelByAdmin() {
+        this.status = ReservationStatus.CANCELLED_BY_ADMIN;
     }
 
     public boolean isOwner(String userName, String phoneLastNumber) {

--- a/src/main/java/com/sayye/reservation/entity/Reservation.java
+++ b/src/main/java/com/sayye/reservation/entity/Reservation.java
@@ -33,7 +33,7 @@ public class Reservation extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "classes_id", nullable = false)
+    @JoinColumn(name = "classes_id")
     private Course course;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -43,7 +43,7 @@ public class Reservation extends BaseEntity {
     @Column(nullable = false)
     private String userName;
 
-    @Column(nullable = false)
+    @Column
     private String phoneLastNumber;
 
     @Enumerated(EnumType.STRING)
@@ -82,6 +82,17 @@ public class Reservation extends BaseEntity {
             .phoneLastNumber(phoneLastNumber)
             .startTime(startTime)
             .status(ReservationStatus.RESERVED)
+            .endTime(endTime)
+            .reservationDate(reservationDate)
+            .build();
+    }
+
+    public static Reservation block(Room room, String userName, LocalTime startTime, LocalTime endTime, LocalDate reservationDate) {
+        return Reservation.builder()
+            .room(room)
+            .userName(userName)
+            .startTime(startTime)
+            .status(ReservationStatus.UNAVAILABLE)
             .endTime(endTime)
             .reservationDate(reservationDate)
             .build();

--- a/src/main/java/com/sayye/reservation/entity/ReservationStatus.java
+++ b/src/main/java/com/sayye/reservation/entity/ReservationStatus.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum ReservationStatus {
     RESERVED("예약"),
     CANCELED("취소"), // 취소됨
+    UNAVAILABLE("예약 불가"), // 예약 불가
     FINISHED("완료");  // 사용 완료
 
     private final String description;

--- a/src/main/java/com/sayye/reservation/entity/ReservationStatus.java
+++ b/src/main/java/com/sayye/reservation/entity/ReservationStatus.java
@@ -9,6 +9,7 @@ public enum ReservationStatus {
     RESERVED("예약"),
     CANCELED("취소"), // 취소됨
     UNAVAILABLE("예약 불가"), // 예약 불가
+    CANCELLED_BY_ADMIN("관리자에 의한 취소"),
     FINISHED("완료");  // 사용 완료
 
     private final String description;

--- a/src/main/java/com/sayye/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/sayye/reservation/repository/ReservationRepository.java
@@ -44,4 +44,17 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     List<Reservation> findByUserNameAndPhoneLastNumberOrderByCreatedAtDesc(String userName,
         String phoneLastNumber);
+
+    @Query("""
+            select r from Reservation r
+            where r.room.id = :roomId
+            and r.reservationDate = :date
+            AND r.status = 'RESERVED'
+            AND ((r.startTime < :endTime) AND (r.endTime > :startTime))
+      """)
+    List<Reservation> findConflictingReservations(@Param("roomId") Long roomId,
+        @Param("date") LocalDate date,
+        @Param("startTime") LocalTime startTime,
+        @Param("endTime") LocalTime endTime
+    );
 }

--- a/src/main/java/com/sayye/reservation/service/AdminReservationService.java
+++ b/src/main/java/com/sayye/reservation/service/AdminReservationService.java
@@ -1,0 +1,44 @@
+package com.sayye.reservation.service;
+
+import com.sayye.reservation.dto.request.AdminReservationReqDto;
+import com.sayye.reservation.dto.response.ReservationResDto;
+import com.sayye.reservation.entity.Reservation;
+import com.sayye.reservation.repository.ReservationRepository;
+import com.sayye.room.entity.Room;
+import com.sayye.room.repository.RoomRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class AdminReservationService {
+
+    private final RoomRepository roomRepository;
+    private final ReservationRepository reservationRepository;
+
+
+    @Transactional
+    public ReservationResDto createAdminReservation(Long roomId, AdminReservationReqDto reqDto, String adminId) {
+        // Todo 회의실 존재 여부 검증
+        Room room = roomRepository.findById(roomId).orElseThrow(() -> new RuntimeException());
+
+        List<Reservation> conflictingReservations = reservationRepository.findConflictingReservations(
+            roomId,
+            reqDto.getReservationDate(),
+            reqDto.getStartTime(),
+            reqDto.getEndTime()
+        );
+
+        // 이미 존재하는 예약을 관리자에 의한 취소 상태로 변경
+        conflictingReservations.forEach(Reservation::cancelByAdmin);
+
+        Reservation adminReservation = reservationRepository.save(reqDto.toEntity(room, adminId));
+
+        return ReservationResDto.from(adminReservation);
+    }
+
+
+}

--- a/src/main/java/com/sayye/reservation/service/ReservationService.java
+++ b/src/main/java/com/sayye/reservation/service/ReservationService.java
@@ -79,6 +79,10 @@ public class ReservationService {
 
     @Transactional
     public ReservationResDto createReservation(Long roomId, ReservationReqDto reqDto) {
+
+        // 현재 시간이 10시 전이면
+        validateBookingAvailableTime();
+
         // 예약 시작 시간이 10시 전이면
         validateReservationTime(reqDto.getStartTime(), reqDto.getEndTime());
 
@@ -192,6 +196,12 @@ public class ReservationService {
         long durationMinutes = Duration.between(startTime, endTime).toMinutes();
         if (durationMinutes > 120) {
             throw new ApiException(ErrorCode.RESERVATION_EXCEED_MAX_DURATION);
+        }
+    }
+
+    private void validateBookingAvailableTime() {
+        if (LocalTime.now().isBefore(LocalTime.of(10, 0))) {
+            throw new ApiException(ErrorCode.RESERVATION_SYSTEM_NOT_OPEN_YET);
         }
     }
 }

--- a/src/main/java/com/sayye/reservation/service/ReservationService.java
+++ b/src/main/java/com/sayye/reservation/service/ReservationService.java
@@ -4,11 +4,12 @@ import com.sayye.course.entity.Course;
 import com.sayye.course.repository.CourseRepository;
 import com.sayye.exception.ApiException;
 import com.sayye.exception.ErrorCode;
+import com.sayye.reservation.dto.request.BlockReqDto;
 import com.sayye.reservation.dto.request.CancelReservationReqDto;
 import com.sayye.reservation.dto.request.ReadReservationReqDto;
+import com.sayye.reservation.dto.request.ReservationReqDto;
 import com.sayye.reservation.dto.request.UpdateReservationReqDto;
 import com.sayye.reservation.dto.response.ReservationAdminResDto;
-import com.sayye.reservation.dto.request.ReservationReqDto;
 import com.sayye.reservation.dto.response.ReservationResDto;
 import com.sayye.reservation.entity.Reservation;
 import com.sayye.reservation.entity.ReservationStatus;
@@ -66,7 +67,8 @@ public class ReservationService {
         return reservations.stream().map(ReservationResDto::from).toList();
     }
 
-    public ReservationResDto getReservationDetail(Long reservationId, ReadReservationReqDto reqDto) {
+    public ReservationResDto getReservationDetail(Long reservationId,
+        ReadReservationReqDto reqDto) {
         Reservation reservation = reservationRepository.findById(reservationId)
             .orElseThrow(() -> new ApiException(ErrorCode.RESERVATION_NOT_FOUND));
 
@@ -136,6 +138,21 @@ public class ReservationService {
             reqDto.getReservationDate());
 
         return ReservationResDto.from(reservation);
+    }
+
+    @Transactional
+    public ReservationResDto blockRoomTime(Long roomId, BlockReqDto reqDto,
+        String adminId) {
+        // Todo 회의실 존재 여부 검증
+        Room room = roomRepository.findById(roomId).orElseThrow(() -> new RuntimeException());
+
+        // 이미 예약되어 있는 시간인지
+        validateOverlap(room.getId(), reqDto.getReservationDate(), reqDto.getStartTime(),
+            reqDto.getEndTime(), null);
+
+        Reservation saved = reservationRepository.save(reqDto.toEntity(room, adminId));
+
+        return ReservationResDto.from(saved);
     }
 
     private Reservation findReservation(Long reservationId) {

--- a/src/main/java/com/sayye/reservation/service/ReservationService.java
+++ b/src/main/java/com/sayye/reservation/service/ReservationService.java
@@ -4,7 +4,7 @@ import com.sayye.course.entity.Course;
 import com.sayye.course.repository.CourseRepository;
 import com.sayye.exception.ApiException;
 import com.sayye.exception.ErrorCode;
-import com.sayye.reservation.dto.request.BlockReqDto;
+import com.sayye.reservation.dto.request.AdminReservationReqDto;
 import com.sayye.reservation.dto.request.CancelReservationReqDto;
 import com.sayye.reservation.dto.request.ReadReservationReqDto;
 import com.sayye.reservation.dto.request.ReservationReqDto;
@@ -138,21 +138,6 @@ public class ReservationService {
             reqDto.getReservationDate());
 
         return ReservationResDto.from(reservation);
-    }
-
-    @Transactional
-    public ReservationResDto blockRoomTime(Long roomId, BlockReqDto reqDto,
-        String adminId) {
-        // Todo 회의실 존재 여부 검증
-        Room room = roomRepository.findById(roomId).orElseThrow(() -> new RuntimeException());
-
-        // 이미 예약되어 있는 시간인지
-        validateOverlap(room.getId(), reqDto.getReservationDate(), reqDto.getStartTime(),
-            reqDto.getEndTime(), null);
-
-        Reservation saved = reservationRepository.save(reqDto.toEntity(room, adminId));
-
-        return ReservationResDto.from(saved);
     }
 
     private Reservation findReservation(Long reservationId) {

--- a/src/main/java/com/sayye/room/controller/RoomController.java
+++ b/src/main/java/com/sayye/room/controller/RoomController.java
@@ -1,6 +1,7 @@
 package com.sayye.room.controller;
 
 
+import com.sayye.reservation.dto.request.BlockReqDto;
 import com.sayye.reservation.dto.request.ReservationReqDto;
 import com.sayye.reservation.dto.response.ReservationResDto;
 import com.sayye.reservation.service.ReservationService;
@@ -13,6 +14,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -68,7 +70,7 @@ public class RoomController {
     ) {
 
         return ResponseEntity.status(HttpStatus.OK)
-                   .body(roomService.updateRoom(roomId, roomReqDto));
+            .body(roomService.updateRoom(roomId, roomReqDto));
     }
 
     // Reservation에서 이동
@@ -76,7 +78,7 @@ public class RoomController {
     public ResponseEntity<ReservationResDto> createReservation(@PathVariable Long roomId,
         @Valid @RequestBody ReservationReqDto reqDto) {
         return ResponseEntity.status(HttpStatus.CREATED)
-                   .body(reservationService.createReservation(roomId, reqDto));
+            .body(reservationService.createReservation(roomId, reqDto));
     }
 
     // Reservation에서 이동
@@ -85,5 +87,12 @@ public class RoomController {
         @PathVariable Long roomId, @RequestParam LocalDate reservationDate) {
         return ResponseEntity.ok(
             reservationService.getReservationsByRoomId(roomId, reservationDate));
+    }
+
+    @PostMapping("/{roomId}/blocks")
+    public ResponseEntity<ReservationResDto> blockRoomTime(@PathVariable Long roomId,
+        @Valid @RequestBody BlockReqDto reqDto, Authentication authentication) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(reservationService.blockRoomTime(roomId, reqDto, authentication.getName()));
     }
 }

--- a/src/main/java/com/sayye/room/controller/RoomController.java
+++ b/src/main/java/com/sayye/room/controller/RoomController.java
@@ -1,7 +1,6 @@
 package com.sayye.room.controller;
 
 
-import com.sayye.reservation.dto.request.BlockReqDto;
 import com.sayye.reservation.dto.request.ReservationReqDto;
 import com.sayye.reservation.dto.response.ReservationResDto;
 import com.sayye.reservation.service.ReservationService;
@@ -14,7 +13,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -89,10 +87,4 @@ public class RoomController {
             reservationService.getReservationsByRoomId(roomId, reservationDate));
     }
 
-    @PostMapping("/{roomId}/blocks")
-    public ResponseEntity<ReservationResDto> blockRoomTime(@PathVariable Long roomId,
-        @Valid @RequestBody BlockReqDto reqDto, Authentication authentication) {
-        return ResponseEntity.status(HttpStatus.CREATED)
-            .body(reservationService.blockRoomTime(roomId, reqDto, authentication.getName()));
-    }
 }


### PR DESCRIPTION
### 작업 내용
* 관리자가 다른 수강생이 특정 시간대에 회의실을 예약할 수 없도록 예약 불가 설정 기능을 추가했습니다.
    * 기존 예약 로직과 유사하게 동작하지만 DB에는 `UNAVAILABLE`로 저장되고 `classes_id`, `phone_last_number`도 `null이 저장되도록 수정했습니다.
    * 일반 예약을 생성과 달리 시작/끝 시간과 날짜만 입력하도록 하였습니다.
* 기존 `validateOverlap` 메서드를 재활용해 이미 예약된 시간에는 불가 설정을 할 수 없도록 검증합니다.
* `Authentication.getName()` 메서드를 통해 현재 요청자의 정보를 가져오지만 실제 DB의 관리자 이름이 아니라 `user_id` 값을 가져와 저장합니다.

### 2차 작업 내용
* 기존 작업 내용의 관리자가 특정 시간대에 예약을 막는 행위는 관리자 또한 회의실을 예약하는 행위와 일치하기 때문에 그냥 관리자용 예약 기능으로 변경했습니다.
   * 일반 예약과 달리 시작/끝 시간과 날짜만 입력하는 건 동일합니다.
   * 관리자는 수강생과 달리 예약에 제약이 없기 때문에 일반 예약자의 검증 로직은 모두 적용하지 않았습니다.
* 이미 수강생이 예약한 시간대라면 해당 수강생의 예약 상태를 `관리자에 의한 취소` 로 수정하도록 했습니다.
* 해당 기능은 관리자에 국한된 기능으로 `AdminControlle`에서 요청을 받을 수 있도록 메서드 추가했고, `AdminReservationService`를 추가해서 해당 클래스에서 처리하도록 분리했습니다.
* 수강생이 예약할 때 현재 예약하는 시간이 10시 전인지 검증하는 로직을 추가했습니다.

#### 놓친게 있을 수 있으니 확인해서 의견주시면 감사하겠습니다.