### PR TITLE
Fix : 회의실 추가시 위치 생략 가능하도록 수정

### DIFF
--- a/src/main/java/com/sayye/room/entity/Room.java
+++ b/src/main/java/com/sayye/room/entity/Room.java
@@ -31,7 +31,6 @@ public class Room extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String roomName;
 
-    @Column(nullable = false)
     private Integer location;
 
     @Column(nullable = false)


### PR DESCRIPTION
## 문제
- 회의실 추가시 위치를 생략하고 생성하게되면 403 예외처리가 발생하는 문제

## 원인
<img width="317" height="71" alt="image" src="https://github.com/user-attachments/assets/30e8847c-de2a-43cf-91ab-0720da2e29ee" />

- Entity 설정시 nullable = false 조건이 포함되어 있어서 발생했던 문제

## 해결
- 해당 컬럼 조건 삭제 후 테스트하니 정상작동