### PR TITLE
Feat : 관리자 이름 및 이메일 중복 검증 로직 추가

### DIFF
--- a/src/main/java/com/sayye/admin/repository/AdminRepository.java
+++ b/src/main/java/com/sayye/admin/repository/AdminRepository.java
@@ -10,4 +10,8 @@ public interface AdminRepository extends JpaRepository<Admin, Long> {
 
     Optional<Admin> findByUserId(String userId);
 
+    boolean existsByEmail(String email);
+
+    boolean existsByName(String name);
+
 }

--- a/src/main/java/com/sayye/admin/service/AdminService.java
+++ b/src/main/java/com/sayye/admin/service/AdminService.java
@@ -72,9 +72,19 @@ public class AdminService {
 
     @Transactional
     public AdminResponse signup(SignupRequest request) {
-        // 중복 체크
+        // userId 중복 체크
         if (adminRepository.findByUserId(request.getUserId()).isPresent()) {
             throw new ApiException(ErrorCode.ADMIN_USER_ID_DUPLICATED);
+        }
+
+        // 관리자 이름 중복 체크
+        if (adminRepository.existsByName(request.getName())) {
+            throw new ApiException(ErrorCode.ADMIN_NAME_DUPLICATED);
+        }
+
+        // 이메일 중복 체크
+        if (adminRepository.existsByEmail(request.getEmail())) {
+            throw new ApiException(ErrorCode.ADMIN_EMAIL_DUPLICATED);
         }
 
         // 정적 팩토리 메서드를 통한 객체 생성

--- a/src/main/java/com/sayye/exception/ErrorCode.java
+++ b/src/main/java/com/sayye/exception/ErrorCode.java
@@ -15,6 +15,8 @@ public enum ErrorCode {
     ADMIN_LOGIN_PASSWORD_INCORRECT(HttpStatus.BAD_REQUEST, "비밀번호를 다시 입력해주세요."),
     ADMIN_PASSWORD_SAME(HttpStatus.BAD_REQUEST, "기존 비밀번호와 새 비밀번호가 동일합니다."),
     ADMIN_USER_ID_DUPLICATED(HttpStatus.CONFLICT, "존재하는 유저입니다."),
+    ADMIN_EMAIL_DUPLICATED(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+    ADMIN_NAME_DUPLICATED(HttpStatus.CONFLICT, "이미 존재하는 관리자 이름입니다."),
     ADMIN_ALREADY_LOGGED_OUT(HttpStatus.BAD_REQUEST, "이미 로그아웃된 유저입니다."),
     ADMIN_ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 


### PR DESCRIPTION
### 관리자 추가 시 이름 및 이메일 중복 검증 로직을 추가하였습니다.

<br>**[ 관리자 ID 중복 검증 ]**

<img width="1439" height="708" alt="스크린샷 2025-12-29 오전 9 41 16" src="https://github.com/user-attachments/assets/01443172-7980-49ff-b9a6-9aead05a6999" />

<br>**[ 관리자 이름 중복 검증 ]**

<img width="1440" height="750" alt="스크린샷 2025-12-29 오전 9 41 29" src="https://github.com/user-attachments/assets/571a511a-a261-43c7-9e8e-aec378912c9d" />

<br>**[ 관리자 이메일 중복 검증 ]**

<img width="1439" height="750" alt="스크린샷 2025-12-29 오전 9 41 40" src="https://github.com/user-attachments/assets/c0ad16c6-c1b5-463a-b951-3db2a829637f" />

<br>**[ 관리자 추가 성공 ]**

<img width="1440" height="749" alt="스크린샷 2025-12-29 오전 9 41 49" src="https://github.com/user-attachments/assets/2d240a01-0955-44bb-b81a-b83e0f1c3f4d" />

<br>**[ 관리자 추가 성공 후 화면 ]**

<img width="1247" height="516" alt="스크린샷 2025-12-29 오전 9 41 59" src="https://github.com/user-attachments/assets/43e3a568-a856-46a2-8244-f99cde65d685" />

<br>
<br>

Closes #52 