### PR TITLE
fix/Admin : 관리자 추가 시, 아이디와 비밀번호 검증 코드 수정.

### DIFF
--- a/src/main/java/com/sayye/admin/dto/request/SignupRequest.java
+++ b/src/main/java/com/sayye/admin/dto/request/SignupRequest.java
@@ -2,7 +2,6 @@ package com.sayye.admin.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -12,14 +11,11 @@ import lombok.RequiredArgsConstructor;
 public class SignupRequest {
 
     @NotBlank(message = "아이디는 필수입니다.")
-    @Size(min = 4, max = 20, message = "아이디는 4자 이상 20자 이하로 입력해주세요.")
-    @Pattern(regexp = "^[a-z0-9]+$", message = "아이디는 영문 소문자와 숫자만 사용 가능합니다.")
+    @Size(min = 4, message = "아이디는 4자 이상이어야 합니다.")
     private final String userId;
 
     @NotBlank(message = "비밀번호는 필수입니다.")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d@$!%*#?&]{8,20}$",
-             message = "비밀번호는 8자 이상 20자 이하의 영문, 숫자를 포함해야 합니다."
-    )
+    @Size(min = 4, message = "비밀번호는 4자 이상이어야 합니다.")
     private final String password;
 
     @NotBlank(message = "이름은 필수입니다.")


### PR DESCRIPTION
### 관리자 추가 시, 아이디와 비밀번호 검증이 까다롭다고 판단하여 최소 글자 길이만 검증할 수 있도록 수정.

<br>

#### [ 변경 사항 ]
- `SignupRequest.java `

<br>

#### [ 프론트엔드 테스트 화면 ]

<br>**1. 아이디 검증**

<img width="1273" height="443" alt="스크린샷 2025-12-31 오전 9 07 05" src="https://github.com/user-attachments/assets/b1d3926c-a3ca-4a05-8cfa-982f3ccecf77" />

<br>**2. 비밀번호 검증**

<img width="1274" height="442" alt="스크린샷 2025-12-31 오전 9 07 13" src="https://github.com/user-attachments/assets/15cbf751-e690-41c2-8ad5-0207abd22c5a" />

<br>**3. 관리자 추가 성공**
<img width="1274" height="438" alt="스크린샷 2025-12-31 오전 9 07 17" src="https://github.com/user-attachments/assets/1049bb7b-4e28-42c7-827a-e550622b6811" />

<br>**4. 관리자 추가 완료**
<img width="1270" height="667" alt="스크린샷 2025-12-31 오전 9 07 33" src="https://github.com/user-attachments/assets/6fbb747e-484e-4251-9748-7bd9685c268b" />


<br>
<br>

Closes #60 