### PR TITLE
Fix: 예약 시 검증 수정

### DIFF
--- a/src/main/java/com/sayye/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/sayye/reservation/repository/ReservationRepository.java
@@ -27,17 +27,17 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
 
     @Query("""
-            select count(r)
-            from  Reservation r
-            where r.room.id = :roomId
-            and r.reservationDate = :date
-            and r.status <> :cancelledStatus
-            and (r.startTime < :endTime and r.endTime > :startTime)
-            and (:excludeId is null or r.id <> :roomId)
-        """)
+        select count(r)
+        from  Reservation r
+        where r.room.id = :roomId
+        and r.reservationDate = :date
+        and r.status NOT IN :excludedStatuses
+        and (r.startTime < :endTime and r.endTime > :startTime)
+        and (:excludeId is null or r.id <> :roomId)
+    """)
     Long existsOverlap(@Param("roomId") Long roomId, @Param("date") LocalDate date,
         @Param("startTime") LocalTime startTime, @Param("endTime") LocalTime endTime,
-        @Param("cancelledStatus") ReservationStatus cancelledStatus,
+        @Param("excludedStatuses") List<ReservationStatus> excludedStatuses,
         @Param("excludeId") Long excludeId);
 
     List<Reservation> findAllByRoomIdAndReservationDateAndStatusNotOrderByStartTimeAsc(Long roomId,

--- a/src/main/java/com/sayye/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/sayye/reservation/repository/ReservationRepository.java
@@ -27,32 +27,33 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
 
     @Query("""
-        select count(r)
-        from  Reservation r
-        where r.room.id = :roomId
-        and r.reservationDate = :date
-        and r.status NOT IN :excludedStatuses
-        and (r.startTime < :endTime and r.endTime > :startTime)
-        and (:excludeId is null or r.id <> :roomId)
-    """)
+            select count(r)
+            from  Reservation r
+            where r.room.id = :roomId
+            and r.reservationDate = :date
+            and r.status NOT IN :excludedStatuses
+            and (r.startTime < :endTime and r.endTime > :startTime)
+            and (:excludeId is null or r.id <> :roomId)
+        """)
     Long existsOverlap(@Param("roomId") Long roomId, @Param("date") LocalDate date,
         @Param("startTime") LocalTime startTime, @Param("endTime") LocalTime endTime,
         @Param("excludedStatuses") List<ReservationStatus> excludedStatuses,
         @Param("excludeId") Long excludeId);
 
-    List<Reservation> findAllByRoomIdAndReservationDateAndStatusNotOrderByStartTimeAsc(Long roomId,
-        LocalDate date, ReservationStatus status);
+    List<Reservation> findAllByRoomIdAndReservationDateAndStatusNotInOrderByStartTimeAsc(
+        Long roomId,
+        LocalDate date, List<ReservationStatus> statuses);
 
     List<Reservation> findByUserNameAndPhoneLastNumberOrderByCreatedAtDesc(String userName,
         String phoneLastNumber);
 
     @Query("""
-            select r from Reservation r
-            where r.room.id = :roomId
-            and r.reservationDate = :date
-            AND r.status = 'RESERVED'
-            AND ((r.startTime < :endTime) AND (r.endTime > :startTime))
-      """)
+              select r from Reservation r
+              where r.room.id = :roomId
+              and r.reservationDate = :date
+              AND r.status = 'RESERVED'
+              AND ((r.startTime < :endTime) AND (r.endTime > :startTime))
+        """)
     List<Reservation> findConflictingReservations(@Param("roomId") Long roomId,
         @Param("date") LocalDate date,
         @Param("startTime") LocalTime startTime,

--- a/src/main/java/com/sayye/reservation/service/ReservationService.java
+++ b/src/main/java/com/sayye/reservation/service/ReservationService.java
@@ -182,7 +182,8 @@ public class ReservationService {
     private void validateOverlap(Long roomId, LocalDate reservationDate, LocalTime startTime,
         LocalTime endTime, Long excludeId) {
         if (reservationRepository.existsOverlap(roomId, reservationDate, startTime, endTime,
-            ReservationStatus.CANCELED, excludeId) > 0) {
+            List.of(ReservationStatus.CANCELED, ReservationStatus.CANCELLED_BY_ADMIN), excludeId)
+            > 0) {
             throw new ApiException(ErrorCode.RESERVATION_TIME_OVERLAPPED);
         }
     }

--- a/src/main/java/com/sayye/reservation/service/ReservationService.java
+++ b/src/main/java/com/sayye/reservation/service/ReservationService.java
@@ -112,8 +112,9 @@ public class ReservationService {
         Room room = roomRepository.findById(roomId).orElseThrow(() -> new RuntimeException());
 
         List<Reservation> reservations = reservationRepository.
-            findAllByRoomIdAndReservationDateAndStatusNotOrderByStartTimeAsc(room.getId(),
-                reservationDate, ReservationStatus.CANCELED);
+            findAllByRoomIdAndReservationDateAndStatusNotInOrderByStartTimeAsc(room.getId(),
+                reservationDate,
+                List.of(ReservationStatus.CANCELED, ReservationStatus.CANCELLED_BY_ADMIN));
 
         return reservations.stream().map(ReservationResDto::from).toList();
 


### PR DESCRIPTION
### 변경 사항
#### 기존
* 회의실 예약 시 이미 예약된 시간인지 검증할 때 `취소(CANCELED)` 상태만 제외하고 예약 상태를 확인함
* 이로 인해 `관리자가 예약을 취소한 경우(CANCELLED_BY_ADMIN)` 에도 해당 시간대가 여전히 예약된 것으로 판단되어 관리자 취소 후 동일 시간대를 다시 예약할 수 없는 문제 발생

#### 변경 내용
* 예약 겹침 검증 시 `일반 취소(CANCELED)` 와 `관리자 취소(CANCELLED_BY_ADMIN)` 상태를 모두 제외하도록 수정
* 관리자가 취소한 예약의 시간대는 다시 예약 가능하도록 동작 개선

#### 기존
* 예약 현황 조회 시 관리자에 의해 취소된 상태의 예약도 조회됨
<img width="300" height="300" alt="스크린샷 2026-01-03 오후 3 58 59" src="https://github.com/user-attachments/assets/c86ed0e7-2a58-41c8-9adc-0745396108ec" />

#### 변경
* 예약 현황 조회 시 관리자에 의한 취소 상태도 일반 취소와 함께 제외
<img width="300" height="300" alt="스크린샷 2026-01-03 오후 4 00 57" src="https://github.com/user-attachments/assets/a1c51dcc-85e0-4d8e-b4e7-624769cad0e0" />

