### PR TITLE
Feat/reservation pessimistic lock

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sayye/notice/entity/Notice.java
+++ b/src/main/java/com/sayye/notice/entity/Notice.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,7 +20,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "notices")
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notice extends BaseEntity {
 
     @Id
@@ -42,8 +43,8 @@ public class Notice extends BaseEntity {
     @JoinColumn(name = "admins_id", nullable = false)
     private Admin admin;
 
-    @Builder
-    public Notice(Admin admin,String title, String content, Boolean status, Boolean pinned){
+    @Builder(access = AccessLevel.PRIVATE)
+    private Notice(Admin admin,String title, String content, Boolean status, Boolean pinned){
         this.admin = admin;
         this.title = title;
         this.content = content;

--- a/src/main/java/com/sayye/reservation/service/ReservationService.java
+++ b/src/main/java/com/sayye/reservation/service/ReservationService.java
@@ -86,7 +86,7 @@ public class ReservationService {
         validateReservationTime(reqDto.getStartTime(), reqDto.getEndTime());
 
         // Todo 회의실 존재 여부 검증
-        Room room = roomRepository.findById(roomId).orElseThrow(() -> new RuntimeException());
+        Room room = roomRepository.findByIdWithLock(roomId).orElseThrow(() -> new RuntimeException());
 
         // Todo 클래스 존재 여부 검증
         Course course = courseRepository.findById(reqDto.getCourseId())

--- a/src/main/java/com/sayye/room/repository/RoomRepository.java
+++ b/src/main/java/com/sayye/room/repository/RoomRepository.java
@@ -2,11 +2,20 @@ package com.sayye.room.repository;
 
 
 import com.sayye.room.entity.Room;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RoomRepository extends JpaRepository<Room, Long> {
 
     boolean existsByRoomName(String roomName);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM Room r WHERE r.id = :id")
+    Optional<Room> findByIdWithLock(Long id);
+
 }

--- a/src/test/java/com/sayye/reservation/service/ReservationConcurrencyTest.java
+++ b/src/test/java/com/sayye/reservation/service/ReservationConcurrencyTest.java
@@ -1,0 +1,278 @@
+package com.sayye.reservation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sayye.course.entity.Course;
+import com.sayye.course.repository.CourseRepository;
+import com.sayye.reservation.dto.request.ReservationReqDto;
+import com.sayye.reservation.entity.ReservationStatus;
+import com.sayye.reservation.repository.ReservationRepository;
+import com.sayye.room.dto.request.RoomReqDto;
+import com.sayye.room.entity.Room;
+import com.sayye.room.repository.RoomRepository;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ReservationConcurrencyTest {
+
+    @Autowired
+    private ReservationService reservationService;
+
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @Autowired
+    private CourseRepository courseRepository;
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    private Room room;
+    private Course course;
+
+    @BeforeEach
+    void setUp() {
+        room = roomRepository.save(Room.of(new RoomReqDto("테스트 회의실", 1, 10, "동시성 테스트용")));
+
+        course = courseRepository.save(Course.builder()
+            .courseName("테스트 클래스")
+            .startDate(LocalDate.now())
+            .endDate(LocalDate.now().plusMonths(3))
+            .build());
+    }
+
+    @AfterEach
+    void cleanUp() {
+        reservationRepository.deleteAll();
+        courseRepository.deleteAll();
+        roomRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("[정상 동작 확인] 같은 방에 겹치지 않는 시간대를 순차 예약하면 모두 성공한다")
+    void 같은_방에_다른_시간대를_순차_예약하면_모두_성공한다() {
+        // given
+        LocalDate tomorrow = LocalDate.now().plusDays(1);
+        List<LocalTime[]> timeSlots = List.of(
+            new LocalTime[]{LocalTime.of(9, 0),  LocalTime.of(10, 0)},
+            new LocalTime[]{LocalTime.of(10, 0), LocalTime.of(11, 0)},
+            new LocalTime[]{LocalTime.of(11, 0), LocalTime.of(12, 0)},
+            new LocalTime[]{LocalTime.of(13, 0), LocalTime.of(14, 0)},
+            new LocalTime[]{LocalTime.of(14, 0), LocalTime.of(15, 0)}
+        );
+
+        // when
+        List<Exception> exceptions = new ArrayList<>();
+        List<Long> successIds = new ArrayList<>();
+
+        for (int i = 0; i < timeSlots.size(); i++) {
+            try {
+                ReservationReqDto reqDto = makeReqDto(
+                    "사용자" + i,
+                    String.format("%04d", i),
+                    course.getId(),
+                    tomorrow,
+                    timeSlots.get(i)[0],
+                    timeSlots.get(i)[1]
+                );
+                var result = reservationService.createReservation(room.getId(), reqDto);
+                successIds.add(result.getId());
+            } catch (Exception e) {
+                exceptions.add(e);
+            }
+        }
+
+        // then
+        long savedCount = reservationRepository.findAll().stream()
+            .filter(r -> r.getRoom().getId().equals(room.getId()))
+            .filter(r -> r.getReservationDate().equals(tomorrow))
+            .filter(r -> r.getStatus() == ReservationStatus.RESERVED)
+            .count();
+
+        System.out.println("==============================");
+        System.out.println(" 순차 예약 테스트 결과 (다른 시간대)");
+        System.out.println("==============================");
+        System.out.println(" 시도한 요청 수    : " + timeSlots.size());
+        System.out.println(" 성공한 예약 수    : " + successIds.size());
+        System.out.println(" 예외 발생 수      : " + exceptions.size());
+        System.out.println(" DB에 저장된 예약  : " + savedCount);
+        System.out.println("------------------------------");
+        exceptions.forEach(e -> System.out.println(" 예외 내용: " + e.getMessage()));
+        System.out.println("==============================");
+
+        assertThat(exceptions).as("겹치지 않는 시간대 예약은 예외 없이 모두 성공해야 한다").isEmpty();
+        assertThat(savedCount).as("모든 예약이 DB에 저장되어야 한다").isEqualTo(timeSlots.size());
+    }
+
+    @Test
+    @DisplayName("[정상 동작 확인] 같은 방에 겹치지 않는 시간대를 동시 예약하면 모두 성공한다")
+    void 같은_방에_다른_시간대를_동시에_예약하면_모두_성공한다() throws InterruptedException {
+        // given
+        int threadCount = 5;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+        LocalDate tomorrow = LocalDate.now().plusDays(1);
+        List<LocalTime[]> timeSlots = List.of(
+            new LocalTime[]{LocalTime.of(9, 0),  LocalTime.of(10, 0)},
+            new LocalTime[]{LocalTime.of(10, 0), LocalTime.of(11, 0)},
+            new LocalTime[]{LocalTime.of(11, 0), LocalTime.of(12, 0)},
+            new LocalTime[]{LocalTime.of(13, 0), LocalTime.of(14, 0)},
+            new LocalTime[]{LocalTime.of(14, 0), LocalTime.of(15, 0)}
+        );
+
+        List<Exception> exceptions = Collections.synchronizedList(new ArrayList<>());
+        List<Long> successIds = Collections.synchronizedList(new ArrayList<>());
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            final int idx = i;
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+
+                    ReservationReqDto reqDto = makeReqDto(
+                        "사용자" + idx,
+                        String.format("%04d", idx),
+                        course.getId(),
+                        tomorrow,
+                        timeSlots.get(idx)[0],
+                        timeSlots.get(idx)[1]
+                    );
+                    var result = reservationService.createReservation(room.getId(), reqDto);
+                    successIds.add(result.getId());
+
+                } catch (Exception e) {
+                    exceptions.add(e);
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        doneLatch.await();
+        executor.shutdown();
+
+        // then
+        long savedCount = reservationRepository.findAll().stream()
+            .filter(r -> r.getRoom().getId().equals(room.getId()))
+            .filter(r -> r.getReservationDate().equals(tomorrow))
+            .filter(r -> r.getStatus() == ReservationStatus.RESERVED)
+            .count();
+
+        System.out.println("==============================");
+        System.out.println(" 동시 예약 테스트 결과 (다른 시간대)");
+        System.out.println("==============================");
+        System.out.println(" 시도한 요청 수    : " + threadCount);
+        System.out.println(" 성공한 예약 수    : " + successIds.size());
+        System.out.println(" 예외 발생 수      : " + exceptions.size());
+        System.out.println(" DB에 저장된 예약  : " + savedCount);
+        System.out.println("------------------------------");
+        exceptions.forEach(e -> System.out.println(" 예외 내용: " + e.getMessage()));
+        System.out.println("==============================");
+
+        assertThat(exceptions).as("겹치지 않는 시간대 동시 예약은 예외 없이 모두 성공해야 한다").isEmpty();
+        assertThat(savedCount).as("모든 예약이 DB에 저장되어야 한다").isEqualTo(threadCount);
+    }
+
+    @Test
+    @DisplayName("[동시성 버그 확인] 동시에 같은 방·시간대에 예약하면 중복 예약이 생성된다")
+    void 동시에_같은_시간에_예약하면_중복_예약이_발생한다() throws InterruptedException {
+        // given
+        int threadCount = 20;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1); // 모든 스레드 동시 출발용
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);  // 모든 스레드 완료 대기용
+
+        LocalDate tomorrow = LocalDate.now().plusDays(1);
+        LocalTime startTime = LocalTime.of(10, 0);
+        LocalTime endTime = LocalTime.of(11, 0);
+
+        List<Exception> exceptions = Collections.synchronizedList(new ArrayList<>());
+        List<Long> successIds = Collections.synchronizedList(new ArrayList<>());
+
+        for (int i = 0; i < threadCount; i++) {
+            final int idx = i;
+            executor.submit(() -> {
+                try {
+                    startLatch.await(); // 신호 전까지 대기 → 동시 출발
+
+                    ReservationReqDto reqDto = makeReqDto(
+                        "사용자" + idx,
+                        String.format("%04d", idx), // 서로 다른 유저 (중복 유저 검증 우회)
+                        course.getId(),
+                        tomorrow, startTime, endTime
+                    );
+                    var result = reservationService.createReservation(room.getId(), reqDto);
+                    successIds.add(result.getId());
+
+                } catch (Exception e) {
+                    exceptions.add(e);
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown(); // 전체 스레드 동시 출발
+        doneLatch.await();      // 모든 스레드 완료까지 대기
+        executor.shutdown();
+
+        // then
+        long savedCount = reservationRepository.findAll().stream()
+            .filter(r -> r.getRoom().getId().equals(room.getId()))
+            .filter(r -> r.getReservationDate().equals(tomorrow))
+            .filter(r -> r.getStatus() == ReservationStatus.RESERVED)
+            .count();
+
+        System.out.println("==============================");
+        System.out.println(" 동시성 테스트 결과");
+        System.out.println("==============================");
+        System.out.println(" 시도한 요청 수    : " + threadCount);
+        System.out.println(" 성공한 예약 수    : " + successIds.size());
+        System.out.println(" 예외 발생 수      : " + exceptions.size());
+        System.out.println(" DB에 저장된 예약  : " + savedCount);
+        System.out.println("==============================");
+
+        if (savedCount > 1) {
+            System.out.println("[FAIL] 동시성 문제 발생! " + savedCount + "개의 중복 예약이 생성됨");
+        } else {
+            System.out.println("[PASS] 동시성 제어 정상 동작 (예약 1건만 생성됨)");
+        }
+
+        // 동시성 제어가 없으면 이 assertion이 통과됨 (버그 존재 = 테스트 성공)
+        assertThat(savedCount)
+            .as("동시성 제어가 없으면 중복 예약이 생성되어야 한다 (버그 확인용)")
+            .isGreaterThan(1);
+    }
+
+    private ReservationReqDto makeReqDto(String userName, String phone, Long courseId,
+        LocalDate date, LocalTime startTime, LocalTime endTime) {
+        ReservationReqDto dto = new ReservationReqDto();
+        ReflectionTestUtils.setField(dto, "courseId", courseId);
+        ReflectionTestUtils.setField(dto, "userName", userName);
+        ReflectionTestUtils.setField(dto, "phoneLastNumber", phone);
+        ReflectionTestUtils.setField(dto, "reservationDate", date);
+        ReflectionTestUtils.setField(dto, "startTime", startTime);
+        ReflectionTestUtils.setField(dto, "endTime", endTime);
+        return dto;
+    }
+}

--- a/src/test/java/com/sayye/reservation/service/ReservationTest.java
+++ b/src/test/java/com/sayye/reservation/service/ReservationTest.java
@@ -1,0 +1,21 @@
+package com.sayye.reservation.service;
+
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@RequiredArgsConstructor
+public class ReservationTest {
+
+    private final ReservationService reservationService;
+
+    @Test
+    @DisplayName("동시성 예약 테스트")
+    void reservationTest(){
+
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,22 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  sql:
+    init:
+      mode: never
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        format_sql: false
+    show-sql: false
+
+jwt:
+  secret: testSecretKeyForJWTTokenGenerationMustBeAtLeast32BytesLong


### PR DESCRIPTION
## 개요
  예약 생성 시 발생할 수 있는 동시성 문제를 비관적 락(Pessimistic Lock)으로 해결합니다.

  ## 변경 사항

  ### 1. Notice 엔티티 접근 제한 강화
  - `@NoArgsConstructor(access = AccessLevel.PROTECTED)` 적용으로 외부 직접 생성 차단
  - `@Builder(access = AccessLevel.PRIVATE)` 및 생성자 private 처리로 무분별한 객체 생성 방지

  ### 2. 예약 생성 시 비관적 락 적용
  - `RoomRepository`에 `@Lock(PESSIMISTIC_WRITE)` 기반 `findByIdWithLock` 쿼리 추가
  - `ReservationService.createReservation`에서 `findById` → `findByIdWithLock`으로 변경
  - 동시에 같은 회의실에 예약 요청이 들어올 경우 DB 레벨에서 순차 처리 보장

  ### 3. 동시성 테스트 추가
  - 겹치지 않는 시간대 순차/동시 예약 → 모두 성공해야 함
  - 같은 시간대 동시 예약 20건 → 중복 예약 발생 여부 확인 (락 적용 전 버그 확인용)
  - 테스트 환경 lombok 의존성 추가

  ## 테스트 방법
  - `ReservationConcurrencyTest` 전체 실행
  - 동시 같은 시간대 예약 테스트에서 1건만 저장되는지 확인
